### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/custom_components/breaking_changes/const.py
+++ b/custom_components/breaking_changes/const.py
@@ -2,7 +2,7 @@
 # Base component constants
 DOMAIN = "breaking_changes"
 DOMAIN_DATA = "{}_data".format(DOMAIN)
-VERSION = "0.3.0"
+VERSION = "0.3.2"
 PLATFORMS = ["sensor"]
 REQUIRED_FILES = ["const.py", "sensor.py"]
 ISSUE_URL = "https://github.com/custom-components/breaking_changes/issues"


### PR DESCRIPTION
I guess since the tag was already created, you'd have to bump to the next version, so I used 0.3.2. Is that ok?