### PR TITLE
Get rid of syntax warning

### DIFF
--- a/custom_components/breaking_changes/__init__.py
+++ b/custom_components/breaking_changes/__init__.py
@@ -141,7 +141,7 @@ async def update_data(hass, throttle):
             _LOGGER.debug(jsondata)
             for platform in jsondata:
                 _LOGGER.debug(platform["component"])
-                if platform["component"] is None or platform["component"] is "None":
+                if platform["component"] is None or platform["component"] == "None":
                     platform["component"] = "homeassistant"
                 if platform["component"] in hass.data[DOMAIN_DATA]["components"]:
                     data = {


### PR DESCRIPTION
```
/config/custom_components/breaking_changes/__init__.py:144: SyntaxWarning: "is" with a literal. Did you mean "=="?
 if platform["component"] is None or platform["component"] is "None":
```