### PR TITLE
force pyhaversion version

### DIFF
--- a/custom_components/breaking_changes/manifest.json
+++ b/custom_components/breaking_changes/manifest.json
@@ -3,7 +3,7 @@
   "name": "Breaking Changes",
   "documentation": "https://github.com/custom-components/breaking_changes",
   "requirements": [
-    "pyhaversion>=3.1.0",
+    "pyhaversion>=3.1.0,<=3.4.2",
     "integrationhelper>=0.2.2"
   ],
   "dependencies": [],


### PR DESCRIPTION
adding max version in manifest.json for pyhaversion because new version of pyhaversion has been totaly rewriting ( fix #36  )