### PR TITLE
Bump pyhaversion to 21.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+venv
+.vscode

--- a/custom_components/breaking_changes/__init__.py
+++ b/custom_components/breaking_changes/__init__.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from integrationhelper import Throttle, WebClient
-from pyhaversion import LocalVersion, PyPiVersion
+from pyhaversion import HaVersion, HaVersionSource
 
 from .const import (
     CONF_NAME,
@@ -92,8 +92,8 @@ async def update_data(hass):
 
     session = async_get_clientsession(hass)
     webclient = WebClient(session)
-    localversion = LocalVersion(hass.loop, session)
-    pypiversion = PyPiVersion(hass.loop, session)
+    localversion = HaVersion(session, source=HaVersionSource.LOCAL)
+    pypiversion = HaVersion(session, source=HaVersionSource.PYPI)
     throttle.set_last_run()
 
     try:

--- a/custom_components/breaking_changes/manifest.json
+++ b/custom_components/breaking_changes/manifest.json
@@ -5,7 +5,6 @@
   "issue_tracker": "https://github.com/custom-components/breaking_changes/issues",
   "requirements": [
     "pyhaversion>=21.3.0",
-
     "integrationhelper>=0.2.2",
     "awesomeversion"
   ],

--- a/custom_components/breaking_changes/manifest.json
+++ b/custom_components/breaking_changes/manifest.json
@@ -4,7 +4,8 @@
   "documentation": "https://github.com/custom-components/breaking_changes",
   "issue_tracker": "https://github.com/custom-components/breaking_changes/issues",
   "requirements": [
-    "pyhaversion==21.3.0",
+    "pyhaversion>=21.3.0",
+
     "integrationhelper>=0.2.2",
     "awesomeversion"
   ],

--- a/custom_components/breaking_changes/manifest.json
+++ b/custom_components/breaking_changes/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/custom-components/breaking_changes",
   "issue_tracker": "https://github.com/custom-components/breaking_changes/issues",
   "requirements": [
-    "pyhaversion>=3.1.0,<=3.4.2",
+    "pyhaversion==21.3.0",
     "integrationhelper>=0.2.2",
     "awesomeversion"
   ],

--- a/custom_components/breaking_changes/manifest.json
+++ b/custom_components/breaking_changes/manifest.json
@@ -12,5 +12,6 @@
   "codeowners": [
     "@ludeeus"
   ],
+  "homeassistant": "2021.4.0b0",
   "version": "0.0.0"
 }

--- a/custom_components/breaking_changes/manifest.json
+++ b/custom_components/breaking_changes/manifest.json
@@ -13,6 +13,5 @@
   "codeowners": [
     "@ludeeus"
   ],
-  "homeassistant": "2021.4.0b0",
   "version": "0.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,6 @@
     "zip_release": true,
     "hide_default_branch": true,
     "filename": "breaking_changes.zip",
-    "domain": "breaking_changes"
+    "domain": "breaking_changes",
+    "homeassistant": "2021.4.0b0"
 }


### PR DESCRIPTION
Fixes #41 

I wasn't sure how to test this. From the PR you shared with me (https://github.com/home-assistant/core/pull/48537) it doesn't look like the API has changed, just the class structure, but if you have thoughts I am all ears. At a minimum would appreciate a good review 🙏🏾 